### PR TITLE
Execute the commands before loading the module.

### DIFF
--- a/Runtime/UnityBCI2000.cs
+++ b/Runtime/UnityBCI2000.cs
@@ -21,6 +21,7 @@ public class UnityBCI2000 : MonoBehaviour
     public string[] Module2Args;
     public string Module3 = "DummyApplication";
     public string[] Module3Args;
+    public string[] commandsInProgDir;
     private Dictionary<string, List<string>> modules;
     public string LogFile;
     public bool LogStates;
@@ -70,7 +71,7 @@ public class UnityBCI2000 : MonoBehaviour
         bci.LogStates = LogStates;
         bci.LogPrompts = LogPrompts;
 
-        bci.Connect();
+        bci.Connect(commandsInProgDir);
 
         List<string> module1ArgsList;
         if (Module1Args.Length == 0)


### PR DESCRIPTION
For example, to link UnityBCI2000 and BCPy2000 (Python), the commands must be executed before loading the module.

```bat
#! ../prog/BCI2000Shell
@cls & ..\prog\BCI2000Shell %0 %* #! && exit /b 0 || exit /b 1\n


execute script FindPortablePython.bat  # this is necessary so that BCI2000 can find Python # <--- this


change directory $BCI2000LAUNCHDIR
show window; set title ${Extract file base $0}
reset system
startup system localhost
start executable SignalGenerator --local
start executable PythonSignalProcessing --local --PythonSigClassFile=file.py --PythonSigShell=0 --PythonSigLog=Siglogger.txt
start executable DummyApplication      --local
wait for connected 600

```
I supported this. 

---

UnityBCI2000 displays it this way.

![2023-05-16 125803](https://github.com/neurotechcenter/BCI2000RemoteNET/assets/72431055/17714b3f-e841-4cdf-a816-ad85bf0a5622)

I am also sending a pull request to https://github.com/neurotechcenter/BCI2000RemoteNET/pull/3 .