### PR TITLE
Add BCI2000 suspend and resume methods

### DIFF
--- a/UnityBCI2000.cs
+++ b/UnityBCI2000.cs
@@ -241,7 +241,22 @@ public class UnityBCI2000 : MonoBehaviour
     {
         bci.SetParameter(name, value);  
     }
-
+    /// <summary>
+    /// Start BCI2000. Also call "SetConfig"
+    /// </summary>
+    public void StartBCI2000(){
+        bci.SetConfig();
+        bci.Start();
+    }
+    /// <summary>
+    /// Suspend BCI2000
+    /// </summary>
+    public void SuspendBCI2000()=>bci.Stop();
+    
+    /// <summary>
+    /// Resume BCI2000
+    /// </summary>
+    public void ResumeBCI2000()=>bci.Start();
     private BCI2000Remote bci = new BCI2000Remote();
     private List<string> statenames = new List<string>();
     private List<string> eventnames = new List<string>();
@@ -309,26 +324,14 @@ public class UnityBCI2000 : MonoBehaviour
 
             if (StartWithScene)
             {
-                bci.SetConfig();
-                bci.Start();
+                StartBCI2000();
             }
             afterFirst = true;
         }
 
 
     }
-    /*
-    public void StartRun()
-    {
-        bci.Start();
-    }
-    
 
-    public void StopRun()
-    {
-        bci.Stop();
-    }
-    */
     private void OnDestroy()
     {
         if (ShutdownWithScene)


### PR DESCRIPTION
Hi, I have a suggestion.
I thought that the [BCI2000 commands](https://www.bci2000.org/mediawiki/index.php/Contributions:BCI2000Command#Start) bci.Start() and bci.Stop() could easily be misread as the start and end of communication, so I added a method to match the operator GUI (Start/Resume, Suspend).
If you find suggestion unnecessary, please reject this PR.
Thank you in advance.

![image](https://github.com/neurotechcenter/UnityBCI2000/assets/72431055/1d4beace-497d-4dea-a0cb-80f471935d33)
@Personator01 