### PR TITLE
Add timeout option

### DIFF
--- a/UnityBCI2000.cs
+++ b/UnityBCI2000.cs
@@ -20,6 +20,11 @@ public class UnityBCI2000 : MonoBehaviour
     //public int TelnetPort;
     public int TelnetPort;
     /// <summary>
+    /// Send and recieve timeout in ms
+    /// If non-Unity modules take a long time to start, the connection will be terminated if this value is not adjusted.
+    /// </summary>
+    public int Timeout = 1000;
+    /// <summary>
     /// Don't start the Source, Processing, or Application modules when starting UnityBCI2000
     /// </summary>
     public bool DontStartModules;
@@ -258,6 +263,7 @@ public class UnityBCI2000 : MonoBehaviour
             bci.TelnetIp = TelnetIp;
         if (TelnetPort != 0)
             bci.TelnetPort = TelnetPort;
+        bci.Timeout = Timeout;
         if (!String.IsNullOrWhiteSpace(LogFile))
             bci.LogFile = LogFile;
         bci.LogStates = LogStates;


### PR DESCRIPTION
Added timeout option.
The default value is 1 second, so if non-Unity modules take a long time to start, the connection will be terminated if this value is not adjusted.